### PR TITLE
Fixes for sidebar issues described in HelpScout 1731

### DIFF
--- a/wp-content/themes/midwestenergynews/sidebar.php
+++ b/wp-content/themes/midwestenergynews/sidebar.php
@@ -10,7 +10,7 @@ if (
 $span_class = (is_archive() || is_search())? 'span4':'span3';
 
 do_action('largo_before_sidebar'); ?>
-<aside id="sidebar" class="<?php echo $span_class; ?>">
+<aside id="sidebar" class="<?php echo $span_class; ?> nocontent">
 	<?php do_action('largo_before_sidebar_content'); ?>
 	<div class="widget-area" role="complementary">
 		<?php


### PR DESCRIPTION
## Changes

- adds the `nocontent` attribute to the sidebar, to match Largo
- narrows the former function `exclude_roundups( $query )` to be extremely explicit about when it runs, so that it won't interfere with the query made in Largo's function `largo_get_term_meta()`: https://github.com/INN/largo/blob/09367b17e4d49578dbcc22d9c0829d3668a1e3f5/inc/term-meta.php#L28

## Why

Sidebars were not displaying correctly on region posts:
- setting the sidebar on the most-recent post in a region set the sidebar for that region's term archive
- setting the sidebar on the term archive set the sidebar on the most-recent post in that term
- having the same most-recent post in two different region terms meant that setting the sidebar for any term changed the sidebar on the other term

The `pre_get_posts` filter `exclude_roundups( $query )` was setting the post type to `array( 'post' )` on *every* query that had a region set in the query.

The function `largo_get_term_meta()` runs a query with a region set and with the post type `array( 'post' )`.

These two factors, combined, meant that the post ID returned when getting the region's term meta post (which contains the sidebar setting) was not the most-recent `_term_meta` post in that term, but was the most-recent `post` post in the term.

This fix prevents that from happening by making sure that the filter only affects:
- Load More Posts queries for that region
- The main query for that region

In all other public-facing situations where posts were being returned, particularly combined region-and-category archives, the posts being returned were already all `post` posts, and so this filter did not need to be applied. In all internal situations, the posts being returned ought not to be messed with.