### PR TITLE
Change the slug to match to output the Western Energy News header on the region tax term landing page

### DIFF
--- a/wp-content/themes/midwestenergynews/taxonomy-region.php
+++ b/wp-content/themes/midwestenergynews/taxonomy-region.php
@@ -26,7 +26,7 @@ $bigStoryPost = $bigStoryPost[0];
 			 * This is similar to largo's archive.php, but with everything
 			 * not related to regions cut out.
 			 */
-			$title = single_term_title( '', false );
+			$title = wp_kses_post( single_term_title( '', false ) );
 			$description = term_description();
 
 			// rss links for custom taxonomies are a little tricky

--- a/wp-content/themes/midwestenergynews/taxonomy-region.php
+++ b/wp-content/themes/midwestenergynews/taxonomy-region.php
@@ -47,18 +47,24 @@ $bigStoryPost = $bigStoryPost[0];
 				largo_hero($post_id);
 
 				// instead of outputting the title text, output the relevant image
-				if ( isset( $title ) ) {
+				if ( ! empty( $title ) ) {
 					if ( is_tax( 'region', 'midwest' ) ) {
+						// Midwest
 						echo '<img src="' . get_stylesheet_directory_uri() . '/images/MidwestEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
 					} else if ( is_tax( 'region', 'southeast' ) ) {
+						// Southeast
 						echo '<img src="' . get_stylesheet_directory_uri() . '/images/SoutheastEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
 					} if ( is_tax( 'region', 'southwest' ) ) {
-						echo '<img src="' . get_stylesheet_directory_uri() . '/images/WesternEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
-					} if ( is_tax( 'region', 'western' ) ) {
+						// Southwest
+						echo '<img src="' . get_stylesheet_directory_uri() . '/images/SouthwestEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
+					} if ( is_tax( 'region', 'west' ) ) {
+						// though the slug is "west", the name is "Western Energy News."
 						echo '<img src="' . get_stylesheet_directory_uri() . '/images/WesternEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
 					} if ( is_tax( 'region', 'northeast' ) ) {
+						// Northeast
 						echo '<img src="' . get_stylesheet_directory_uri() . '/images/NortheastEnergyNews_Logo.svg' . '" alt="' . $title  . '" class="region-header" />';
 					} else {
+						// all other cases
 						echo '<h1 class="page-title">' . $title . '</h1>';
 					}
 				}


### PR DESCRIPTION
## Why

For https://secure.helpscout.net/conversation/621107850/2267/?folderId=1219602

We expected the slug to be "western" instead of "west".