### PR TITLE
remove automatic addition of newsletter to front of old stories.

### DIFF
--- a/wp-content/themes/midwestenergynews/inc/newsletter-shortcode.php
+++ b/wp-content/themes/midwestenergynews/inc/newsletter-shortcode.php
@@ -16,14 +16,3 @@ function mwen_newsletter_signup($attrs=null) {
 	return ob_get_clean();
 }
 add_shortcode( 'newsletter_signup', 'mwen_newsletter_signup' );
-
-/**
- * Also render the newsletter signup form on pages published before June 30, 2015
- */
-function mwen_add_newsletter_signup_to_old_posts() {
-	global $post;
-	if ( !is_admin() && strtotime( '2015-06-30 00:00:00' ) > strtotime( $post->post_date ) ) {
-		print mwen_newsletter_signup( array( 'reverse' => true ) );
-	}
-}
-add_action( 'mwen_pre_largo_entry_content', 'mwen_add_newsletter_signup_to_old_posts' );

--- a/wp-content/themes/midwestenergynews/inc/post-tags.php
+++ b/wp-content/themes/midwestenergynews/inc/post-tags.php
@@ -5,14 +5,27 @@
  *
  * Note that this completely ignores the Largo_Byline class.
  *
+ * This MUST be compatible with Largo's implementation: https://github.com/INN/largo/blob/v0.6.4/inc/post-tags.php#L123
+ *
+ * @param Boolean $echo Echo the string or return it (default: echo)
+ * @param Boolean $exclude_date Whether to exclude the date from byline (default: false)
+ * @param WP_Post|Integer $post The post object or ID to get the byline for. Defaults to current post.
+ * @return String Byline as formatted html
  */
 function largo_byline( $echo = true, $exclude_date = false, $post_id = null ) {
 	if (!empty($post_id)) {
-		if (is_object($post_id)) {
+		if (is_object($post)) {
 			$post_id = $post->ID;
+		} else if (is_numeric($post)) {
+			$post_id = $post;
 		}
+
 	} else {
 		$post_id = get_the_ID();
+
+		if ( WP_DEBUG || LARGO_DEBUG ) {
+			_doing_it_wrong( 'largo_byline', 'largo_byline must be called with a post or post ID specified as the third argument. For more information, see https://github.com/INN/largo/issues/1517 .', '0.6' );
+		}
 	}
 
 	$values = get_post_custom( $post_id );

--- a/wp-content/themes/midwestenergynews/partials/content-single-classic.php
+++ b/wp-content/themes/midwestenergynews/partials/content-single-classic.php
@@ -21,7 +21,7 @@
 
 	<div class="row story-row">
 		<div class="span3">
-			<h5 class="byline"><?php largo_byline(); ?></h5>
+			<h5 class="byline"><?php largo_byline( true, false, $post->ID ); ?></h5>
 			<?php
 				if ( $thumb_id = get_post_thumbnail_id( $post->ID ) ) {
 					$thumb_custom = get_post_custom( $thumb_id );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the function that automatically adds the MWEN Newsletter Signup widget to old articles, as a shortcode inserted directly upon the post content when the page is rendered.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Fixes #64 

## Testing/Questions

Features that this PR affects:

- articles before 2015-06-30

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Check out `master`
2. Find a post from before 2015-06-30, like `/?p=610420`
3. Observe the newsletter signup form
4. Check out this branch.
5. Refresh your browser.
6. Observe that the form is gone.