### PR TITLE
remove automatic addition of newsletter to front of old stories.

### DIFF
--- a/wp-content/themes/midwestenergynews/inc/newsletter-shortcode.php
+++ b/wp-content/themes/midwestenergynews/inc/newsletter-shortcode.php
@@ -16,14 +16,3 @@ function mwen_newsletter_signup($attrs=null) {
 	return ob_get_clean();
 }
 add_shortcode( 'newsletter_signup', 'mwen_newsletter_signup' );
-
-/**
- * Also render the newsletter signup form on pages published before June 30, 2015
- */
-function mwen_add_newsletter_signup_to_old_posts() {
-	global $post;
-	if ( !is_admin() && strtotime( '2015-06-30 00:00:00' ) > strtotime( $post->post_date ) ) {
-		print mwen_newsletter_signup( array( 'reverse' => true ) );
-	}
-}
-add_action( 'mwen_pre_largo_entry_content', 'mwen_add_newsletter_signup_to_old_posts' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the function that automatically adds the MWEN Newsletter Signup widget to old articles, as a shortcode inserted directly upon the post content when the page is rendered.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Fixes #64, replaces https://github.com/INN/umbrella-energynewsnetwork/pull/67 which had other commits tangled in.

## Testing/Questions

Features that this PR affects:

- articles before 2015-06-30

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Check out `master`
2. Find a post from before 2015-06-30, like `/?p=610420`
3. Observe the newsletter signup form
4. Check out this branch.
5. Refresh your browser.
6. Observe that the form is gone.