### PR TITLE
Fix bug where Link Roundups were appearing on the Region archive page

### DIFF
--- a/wp-content/themes/midwestenergynews/functions.php
+++ b/wp-content/themes/midwestenergynews/functions.php
@@ -98,14 +98,6 @@ function mwe_responsive_embed($html, $url, $attr, $post_ID) {
 add_filter( 'embed_oembed_html', 'mwe_responsive_embed', 10, 4 );
 
 /**
- * Change 'Load more posts' button text to 'More posts'
- */
-function mwen_next_posts_link($link) {
-  return str_replace('Load more posts', 'More posts', $link);
-}
-add_filter('largo_next_posts_link', 'mwen_next_posts_link');
-
-/**
  * Remove the top image from posts pre-migration.
  *
  * This is similar to `largo_remove_hero`, and derives from it, but is different.
@@ -241,39 +233,6 @@ function mwen_comments_roundups( $value ) {
     return $value;
 }
 add_filter( 'close_comments_for_post_types', 'mwen_comments_roundups' );
-
-/**
- * exclude Roundups from Regions loop
- *
- * This should _only_ run on the regions page, and not anywhere else
- *
- * @param query WP_Query the query that may be about to be run
- * @return WP_Query the query
- * @since Largo 0.5.5.4
- * @since WordPress 4.9.2
- */
-function lmp_exclude_roundups( $query ) {
-
-	/*
-	 * make it happen when loading the page
-	 */
-	if ( ! is_admin() && $query->is_tax('region') && $query->is_main_query() ) {
-		$query->set( 'post_type', array('post') );
-	}
-
-	/*
-	 * make it happen for Load More Posts
-	 *
-	 * Note that is_admin may be true while running LMP
-	 * and is_admin is true when updating a post or updating a term meta
-	 * so we cannot simply allow or disallow based on is_admin
-	 */
-	if ( isset( $_POST ) && isset( $_post['action'] ) && 'load_more_posts' === $_POST['action'] && $query->is_tax('region') ) {
-		$query->set( 'post_type', array('post') );
-	}
-	return $query;
-}
-add_action( 'pre_get_posts', 'lmp_exclude_roundups' );
 
 /**
  * Add new image size

--- a/wp-content/themes/midwestenergynews/inc/load-more-posts.php
+++ b/wp-content/themes/midwestenergynews/inc/load-more-posts.php
@@ -48,7 +48,6 @@ add_filter( 'largo_lmp_template_partial', 'mwen_largo_lmp_template_partial', 10,
  * @since WordPress 4.9.2
  */
 function lmp_exclude_roundups( $query ) {
-
 	/*
 	 * make it happen when loading the page
 	 */
@@ -63,7 +62,12 @@ function lmp_exclude_roundups( $query ) {
 	 * and is_admin is true when updating a post or updating a term meta
 	 * so we cannot simply allow or disallow based on is_admin
 	 */
-	if ( isset( $_POST ) && isset( $_post['action'] ) && 'load_more_posts' === $_POST['action'] && $query->is_tax('region') ) {
+	if (
+		isset( $_POST )
+		&& isset( $_POST['action'] )
+		&& 'load_more_posts' === $_POST['action']
+		&& $query->is_tax('region')
+	) {
 		$query->set( 'post_type', array('post') );
 	}
 	return $query;

--- a/wp-content/themes/midwestenergynews/inc/load-more-posts.php
+++ b/wp-content/themes/midwestenergynews/inc/load-more-posts.php
@@ -6,6 +6,14 @@
  */
 
 /**
+ * Change 'Load more posts' button text to 'More posts'
+ */
+function mwen_next_posts_link($link) {
+	return str_replace('Load more posts', 'More posts', $link);
+}
+add_filter('largo_next_posts_link', 'mwen_next_posts_link');
+
+/**
  * Filter the Largo LMP query to use a region-specific partial
  *
  * @param string $partial The partial sub-slug, of the format `partials/content-$partial`
@@ -27,3 +35,37 @@ function mwen_largo_lmp_template_partial( $partial, $post_query ) {
 	return $partial;
 }
 add_filter( 'largo_lmp_template_partial', 'mwen_largo_lmp_template_partial', 10, 2 );
+
+
+/**
+ * exclude Roundups from Regions loop
+ *
+ * This should _only_ run on the regions page, and not anywhere else
+ *
+ * @param query WP_Query the query that may be about to be run
+ * @return WP_Query the query
+ * @since Largo 0.5.5.4
+ * @since WordPress 4.9.2
+ */
+function lmp_exclude_roundups( $query ) {
+
+	/*
+	 * make it happen when loading the page
+	 */
+	if ( ! is_admin() && $query->is_tax('region') && $query->is_main_query() ) {
+		$query->set( 'post_type', array('post') );
+	}
+
+	/*
+	 * make it happen for Load More Posts
+	 *
+	 * Note that is_admin may be true while running LMP
+	 * and is_admin is true when updating a post or updating a term meta
+	 * so we cannot simply allow or disallow based on is_admin
+	 */
+	if ( isset( $_POST ) && isset( $_post['action'] ) && 'load_more_posts' === $_POST['action'] && $query->is_tax('region') ) {
+		$query->set( 'post_type', array('post') );
+	}
+	return $query;
+}
+add_action( 'pre_get_posts', 'lmp_exclude_roundups' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- corrects a `$_post` to `$_POST`
- moves all the Load More Posts-related code in this theme into `inc/load-more-posts.php`, for ease of finding it all

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Fixes #65 by ensuring that a conditional, which checks whether an argument is set in the POSTed params, will not always return false, by correcting the variable name that is checked to the proper name of the array containing the POSTed data

## Testing/Questions

Features that this PR affects:

- the "Load More Posts" button on region pages, such as `/region/midwest/`

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. check out master/staging
2. visit `/region/midwest/` and click the "More Posts" button until the page contains an element matching the selector `#homepage-bottom article:not(.type-post)` or `#homepage-bottom article.type-roundup`: this is a Roundup, which should not be appearing in the LMP return
3. check out this branch
3. Refresh `/region/midwest/` and continue clicking until you're satisfied that no markup matching that selector are being returned by the LMP AJAX query.