### PR TITLE
remove getsitecontrol compat from mwen theme

### DIFF
--- a/wp-content/themes/midwestenergynews/inc/header-footer.php
+++ b/wp-content/themes/midwestenergynews/inc/header-footer.php
@@ -7,21 +7,3 @@ function largo_component_add_search_box_main_nav() {
 	get_template_part( 'partials/largo-component-main-nav-search-form' );
 }
 add_action( 'largo_after_main_nav_shelf' , 'largo_component_add_search_box_main_nav' );
-
-/**
- * Add the Get Site Control widget javascript to the footer
- *
- * Because for some reason the GSC plugin isn't adding these.
- *
- * @link https://secure.helpscout.net/conversation/522494268/1745/
- */
-function enn_getsitecontrol_script() {
-	?>
-	<script>
-		(function (w,i,d,g,e,t,s) {w[d] = w[d]||[];t= i.createElement(g);
-			t.async=1;t.src=e;s=i.getElementsByTagName(g)[0];s.parentNode.insertBefore(t, s);
-		})(window, document, '_gscq','script','//widgets.getsitecontrol.com/122526/script.js');
-	</script>
-	<?php
-}
-add_action( 'wp_footer', 'enn_getsitecontrol_script', 10 );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes hardcoded support for GetSiteControl from the child theme

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #73

## Testing/Questions

Features that this PR affects:

- Since we're removing the GetSiteControl plugin as well, none

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. none