### PR TITLE
Set show_in_rest to true for region taxonomy.

### DIFF
--- a/wp-content/plugins/usen-region-taxonomy/usen-region-taxonomy.php
+++ b/wp-content/plugins/usen-region-taxonomy/usen-region-taxonomy.php
@@ -193,6 +193,7 @@ final class USEN_Regions_Taxonomy {
 		$args = array(
 			'public' => true,
 			'pubicly_queryable' => true,
+			'show_in_rest' => true,
 			'show_ui' => true,
 			'show_tagcloud' => false,
 			'show_admin_column' => false,


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Enables the Region taxonomy metabox in the Block Editor.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #90 

## Testing/Questions

Features that this PR affects:

- The post editor

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. On the `staging` branch, view a `post`-type post's post editor. See the lack of a way to change a region on the post.
2. Check out this branch.
3. Refresh the editor page.
4. You should now see the "Region" box in the "Document" pane of the editor.